### PR TITLE
Added minimum dimension crop property

### DIFF
--- a/cropper/src/main/java/com/smarttoolfactory/cropper/settings/CropDefaults.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/settings/CropDefaults.kt
@@ -39,7 +39,8 @@ object CropDefaults {
         zoomable: Boolean = true,
         rotatable: Boolean = false,
         fixedAspectRatio: Boolean = false,
-        requiredSize: IntSize? = null
+        requiredSize: IntSize? = null,
+        minDimension: IntSize? = null,
     ): CropProperties {
         return CropProperties(
             cropType = cropType,
@@ -54,7 +55,8 @@ object CropDefaults {
             zoomable = zoomable,
             rotatable = rotatable,
             fixedAspectRatio = fixedAspectRatio,
-            requiredSize = requiredSize
+            requiredSize = requiredSize,
+            minDimension = minDimension,
         )
     }
 
@@ -100,7 +102,8 @@ data class CropProperties internal constructor(
     val zoomable: Boolean,
     val maxZoom: Float,
     val fixedAspectRatio: Boolean = false,
-    val requiredSize: IntSize? = null
+    val requiredSize: IntSize? = null,
+    val minDimension: IntSize? = null,
 )
 
 /**

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropState.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropState.kt
@@ -29,7 +29,6 @@ fun rememberCropState(
 
     // Properties of crop state
     val handleSize = cropProperties.handleSize
-    val minOverlaySize = handleSize * 2
     val cropType = cropProperties.cropType
     val aspectRatio = cropProperties.aspectRatio
     val overlayRatio = cropProperties.overlayRatio
@@ -39,6 +38,7 @@ fun rememberCropState(
     val pannable = cropProperties.pannable
     val rotatable = cropProperties.rotatable
     val fixedAspectRatio = cropProperties.fixedAspectRatio
+    val minDimension = cropProperties.minDimension
 
     return remember(*keys) {
         when (cropType) {
@@ -67,13 +67,13 @@ fun rememberCropState(
                     overlayRatio = overlayRatio,
                     maxZoom = maxZoom,
                     handleSize = handleSize,
-                    minOverlaySize = minOverlaySize,
                     fling = fling,
                     zoomable = zoomable,
                     pannable = pannable,
                     rotatable = rotatable,
                     limitPan = true,
                     fixedAspectRatio = fixedAspectRatio,
+                    minDimension = minDimension,
                 )
             }
         }


### PR DESCRIPTION
Added an option to set minimum crop dimension. Defaults to the existing implementation where minimum dimension is `handleSize * 2`.

In the video demo below, the minimum dimension was set to 600 x 400.

https://github.com/SmartToolFactory/Compose-Cropper/assets/149684/bb0a6b0d-6883-4bdc-a4f9-a076fa37ff65


