### PR TITLE
Added an option to enable fixed cropping aspect ratio

### DIFF
--- a/app/src/main/java/com/smarttoolfactory/composecropper/preferences/CropPropertySelection.kt
+++ b/app/src/main/java/com/smarttoolfactory/composecropper/preferences/CropPropertySelection.kt
@@ -63,6 +63,16 @@ internal fun CropPropertySelectionMenu(
         }
     )
 
+    Title("Fix aspect ratio")
+    FixedAspectRatioEnableSelection(
+        fixedAspectRatioEnabled = cropProperties.fixedAspectRatio,
+        onFixedAspectRatioChanged = {
+            onCropPropertiesChange(
+                cropProperties.copy(fixedAspectRatio = it)
+            )
+        }
+    )
+
     Title("Frame")
     CropFrameSelection(
         aspectRatio = aspectRatio,
@@ -191,6 +201,18 @@ internal fun FlingEnableSelection(
         onStateChange = onFlingEnabledChange
     )
 
+}
+
+@Composable
+internal fun FixedAspectRatioEnableSelection(
+    fixedAspectRatioEnabled: Boolean,
+    onFixedAspectRatioChanged: (Boolean) -> Unit
+) {
+    FullRowSwitch(
+        label = "Enable fixed aspect ratio",
+        state = fixedAspectRatioEnabled,
+        onStateChange = onFixedAspectRatioChanged
+    )
 }
 
 @Composable

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/ImageCropper.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/ImageCropper.kt
@@ -96,13 +96,20 @@ fun ImageCropper(
 
         val cropType = cropProperties.cropType
         val contentScale = cropProperties.contentScale
-
+        val fixedAspectRatio = cropProperties.fixedAspectRatio
         val cropOutline = cropProperties.cropOutlineProperty.cropOutline
 
         // these keys are for resetting cropper when image width/height, contentScale or
         // overlay aspect ratio changes
         val resetKeys =
-            getResetKeys(scaledImageBitmap, imageWidthPx, imageHeightPx, contentScale, cropType)
+            getResetKeys(
+                scaledImageBitmap,
+                imageWidthPx,
+                imageHeightPx,
+                contentScale,
+                cropType,
+                fixedAspectRatio
+            )
 
         val cropState = rememberCropState(
             imageSize = IntSize(bitmapWidth, bitmapHeight),
@@ -337,19 +344,22 @@ private fun getResetKeys(
     imageWidthPx: Int,
     imageHeightPx: Int,
     contentScale: ContentScale,
-    cropType: CropType
+    cropType: CropType,
+    fixedAspectRatio: Boolean,
 ) = remember(
     scaledImageBitmap,
     imageWidthPx,
     imageHeightPx,
     contentScale,
-    cropType
+    cropType,
+    fixedAspectRatio,
 ) {
     arrayOf(
         scaledImageBitmap,
         imageWidthPx,
         imageHeightPx,
         contentScale,
-        cropType
+        cropType,
+        fixedAspectRatio,
     )
 }

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/model/AspectRatios.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/model/AspectRatios.kt
@@ -18,8 +18,8 @@ val aspectRatios = listOf(
     ),
     CropAspectRatio(
         title = "Original",
-        shape = createRectShape(AspectRatio.Unspecified),
-        aspectRatio = AspectRatio.Unspecified
+        shape = createRectShape(AspectRatio.Original),
+        aspectRatio = AspectRatio.Original
     ),
     CropAspectRatio(
         title = "1:1",

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/model/CropAspectRatio.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/model/CropAspectRatio.kt
@@ -11,17 +11,17 @@ import androidx.compose.ui.graphics.Shape
 data class CropAspectRatio(
     val title: String,
     val shape: Shape,
-    val aspectRatio: AspectRatio = AspectRatio.Unspecified,
+    val aspectRatio: AspectRatio = AspectRatio.Original,
     val icons: List<Int> = listOf()
 )
 
 /**
  * Value class for containing aspect ratio
- * and [AspectRatio.Unspecified] for comparing
+ * and [AspectRatio.Original] for comparing
  */
 @Immutable
 data class AspectRatio(val value: Float) {
     companion object {
-        val Unspecified = AspectRatio(-1f)
+        val Original = AspectRatio(-1f)
     }
 }

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/settings/CropDefaults.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/settings/CropDefaults.kt
@@ -32,11 +32,12 @@ object CropDefaults {
         contentScale: ContentScale = ContentScale.Fit,
         cropOutlineProperty: CropOutlineProperty,
         aspectRatio: AspectRatio = aspectRatios[2].aspectRatio,
-        overlayRatio:Float = .9f,
+        overlayRatio: Float = .9f,
         pannable: Boolean = true,
         fling: Boolean = false,
         zoomable: Boolean = true,
-        rotatable: Boolean = false
+        rotatable: Boolean = false,
+        fixedAspectRatio: Boolean = false,
     ): CropProperties {
         return CropProperties(
             cropType = cropType,
@@ -49,7 +50,8 @@ object CropDefaults {
             pannable = pannable,
             fling = fling,
             zoomable = zoomable,
-            rotatable = rotatable
+            rotatable = rotatable,
+            fixedAspectRatio = fixedAspectRatio,
         )
     }
 
@@ -94,6 +96,7 @@ data class CropProperties internal constructor(
     val rotatable: Boolean,
     val zoomable: Boolean,
     val maxZoom: Float,
+    val fixedAspectRatio: Boolean = false,
 )
 
 /**

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropState.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropState.kt
@@ -38,7 +38,7 @@ fun rememberCropState(
     val zoomable = cropProperties.zoomable
     val pannable = cropProperties.pannable
     val rotatable = cropProperties.rotatable
-
+    val fixedAspectRatio = cropProperties.fixedAspectRatio
 
     return remember(*keys) {
         when (cropType) {
@@ -72,7 +72,8 @@ fun rememberCropState(
                     zoomable = zoomable,
                     pannable = pannable,
                     rotatable = rotatable,
-                    limitPan = true
+                    limitPan = true,
+                    fixedAspectRatio = fixedAspectRatio,
                 )
             }
         }

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
@@ -403,7 +403,7 @@ abstract class CropState internal constructor(
         coefficient: Float
     ): Rect {
 
-        if (aspectRatio == AspectRatio.Unspecified) {
+        if (aspectRatio == AspectRatio.Original) {
 
             // Maximum width and height overlay rectangle can be measured with
             val overlayWidthMax = drawAreaWidth.coerceAtMost(containerWidth * coefficient)

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
@@ -74,7 +74,6 @@ abstract class CropState internal constructor(
             containerSize.width.toFloat(),
             containerSize.height.toFloat(),
             drawAreaSize.width.toFloat(),
-            drawAreaSize.height.toFloat(),
             aspectRatio,
             overlayRatio
         ),
@@ -158,7 +157,6 @@ abstract class CropState internal constructor(
                     containerSize.width.toFloat(),
                     containerSize.height.toFloat(),
                     drawAreaSize.width.toFloat(),
-                    drawAreaSize.height.toFloat(),
                     aspectRatio,
                     overlayRatio
                 )
@@ -398,16 +396,17 @@ abstract class CropState internal constructor(
         containerWidth: Float,
         containerHeight: Float,
         drawAreaWidth: Float,
-        drawAreaHeight: Float,
         aspectRatio: AspectRatio,
         coefficient: Float
     ): Rect {
 
         if (aspectRatio == AspectRatio.Original) {
+            val imageAspectRatio = imageSize.width.toFloat() / imageSize.height.toFloat()
 
             // Maximum width and height overlay rectangle can be measured with
             val overlayWidthMax = drawAreaWidth.coerceAtMost(containerWidth * coefficient)
-            val overlayHeightMax = drawAreaHeight.coerceAtMost(containerHeight * coefficient)
+            val overlayHeightMax =
+                (overlayWidthMax / imageAspectRatio).coerceAtMost(containerHeight * coefficient)
 
             val offsetX = (containerWidth - overlayWidthMax) / 2f
             val offsetY = (containerHeight - overlayHeightMax) / 2f

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/DynamicCropState.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/DynamicCropState.kt
@@ -265,7 +265,6 @@ class DynamicCropState internal constructor(
                     containerSize.width.toFloat(),
                     containerSize.height.toFloat(),
                     drawAreaSize.width.toFloat(),
-                    drawAreaSize.height.toFloat(),
                     aspectRatio,
                     overlayRatio
                 )

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/DynamicCropState.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/DynamicCropState.kt
@@ -149,7 +149,7 @@ class DynamicCropState internal constructor(
     }
 
     private fun getAspectRatio(): Float {
-        return if (aspectRatio == AspectRatio.Unspecified) {
+        return if (aspectRatio == AspectRatio.Original) {
             imageSize.width / imageSize.height.toFloat()
         } else {
             aspectRatio.value

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/DynamicCropState.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/DynamicCropState.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.coroutineScope
  * @param pannable when set to true pan is enabled
  * @param rotatable when set to true rotation is enabled
  * @param limitPan limits pan to bounds of parent Composable. Using this flag prevents creating
+ * @param fixedAspectRatio when set to true aspect ratio of overlay is fixed
  * empty space on sides or edges of parent
  */
 class DynamicCropState internal constructor(
@@ -43,7 +44,8 @@ class DynamicCropState internal constructor(
     zoomable: Boolean,
     pannable: Boolean,
     rotatable: Boolean,
-    limitPan: Boolean
+    limitPan: Boolean,
+    private val fixedAspectRatio: Boolean,
 ) : CropState(
     imageSize = imageSize,
     containerSize = containerSize,
@@ -86,7 +88,7 @@ class DynamicCropState internal constructor(
     override suspend fun updateProperties(cropProperties: CropProperties, forceUpdate: Boolean) {
         handleSize = cropProperties.handleSize
         minOverlaySize = handleSize * 2
-        
+
         super.updateProperties(cropProperties, forceUpdate)
     }
 
@@ -137,10 +139,20 @@ class DynamicCropState internal constructor(
                 minDimension = minOverlaySize,
                 rectTemp = rectTemp,
                 overlayRect = overlayRect,
-                change = change
+                change = change,
+                aspectRatio = getAspectRatio(),
+                fixedAspectRatio = fixedAspectRatio,
             )
 
             snapOverlayRectTo(newRect)
+        }
+    }
+
+    private fun getAspectRatio(): Float {
+        return if (aspectRatio == AspectRatio.Unspecified) {
+            imageSize.width / imageSize.height.toFloat()
+        } else {
+            aspectRatio.value
         }
     }
 
@@ -351,7 +363,9 @@ class DynamicCropState internal constructor(
         minDimension: Float,
         rectTemp: Rect,
         overlayRect: Rect,
-        change: PointerInputChange
+        change: PointerInputChange,
+        aspectRatio: Float,
+        fixedAspectRatio: Boolean,
     ): Rect {
 
         val position = change.position
@@ -368,7 +382,15 @@ class DynamicCropState internal constructor(
                 // Set position of top left while moving with top left handle and
                 // limit position to not intersect other handles
                 val left = screenPositionX.coerceAtMost(rectTemp.right - minDimension)
-                val top = screenPositionY.coerceAtMost(rectTemp.bottom - minDimension)
+                val top = if (fixedAspectRatio) {
+                    // If aspect ratio is fixed we need to calculate top position based on
+                    // left position and aspect ratio
+                    val width = rectTemp.right - left
+                    val height = width / aspectRatio
+                    rectTemp.bottom - height
+                } else {
+                    screenPositionY.coerceAtMost(rectTemp.bottom - minDimension)
+                }
                 Rect(
                     left = left,
                     top = top,
@@ -382,7 +404,15 @@ class DynamicCropState internal constructor(
                 // Set position of top left while moving with bottom left handle and
                 // limit position to not intersect other handles
                 val left = screenPositionX.coerceAtMost(rectTemp.right - minDimension)
-                val bottom = screenPositionY.coerceAtLeast(rectTemp.top + minDimension)
+                val bottom = if (fixedAspectRatio) {
+                    // If aspect ratio is fixed we need to calculate bottom position based on
+                    // left position and aspect ratio
+                    val width = rectTemp.right - left
+                    val height = width / aspectRatio
+                    rectTemp.top + height
+                } else {
+                    screenPositionY.coerceAtLeast(rectTemp.top + minDimension)
+                }
                 Rect(
                     left = left,
                     top = rectTemp.top,
@@ -396,7 +426,15 @@ class DynamicCropState internal constructor(
                 // Set position of top left while moving with top right handle and
                 // limit position to not intersect other handles
                 val right = screenPositionX.coerceAtLeast(rectTemp.left + minDimension)
-                val top = screenPositionY.coerceAtMost(rectTemp.bottom - minDimension)
+                val top = if (fixedAspectRatio) {
+                    // If aspect ratio is fixed we need to calculate top position based on
+                    // right position and aspect ratio
+                    val width = right - rectTemp.left
+                    val height = width / aspectRatio
+                    rectTemp.bottom - height
+                } else {
+                    screenPositionY.coerceAtMost(rectTemp.bottom - minDimension)
+                }
 
                 Rect(
                     left = rectTemp.left,
@@ -412,7 +450,15 @@ class DynamicCropState internal constructor(
                 // Set position of top left while moving with bottom right handle and
                 // limit position to not intersect other handles
                 val right = screenPositionX.coerceAtLeast(rectTemp.left + minDimension)
-                val bottom = screenPositionY.coerceAtLeast(rectTemp.top + minDimension)
+                val bottom = if (fixedAspectRatio) {
+                    // If aspect ratio is fixed we need to calculate bottom position based on
+                    // right position and aspect ratio
+                    val width = right - rectTemp.left
+                    val height = width / aspectRatio
+                    rectTemp.top + height
+                } else {
+                    screenPositionY.coerceAtLeast(rectTemp.top + minDimension)
+                }
 
                 Rect(
                     left = rectTemp.left,

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/util/ShapeUtils.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/util/ShapeUtils.kt
@@ -81,7 +81,7 @@ fun createRectShape(aspectRatio: AspectRatio): GenericShape {
         val width = size.width
         val height = size.height
         val shapeSize =
-            if (aspectRatio == AspectRatio.Unspecified) Size(width, height)
+            if (aspectRatio == AspectRatio.Original) Size(width, height)
             else if (value > 1) Size(width = width, height = width / value)
             else Size(width = height * value, height = height)
 
@@ -154,7 +154,7 @@ fun calculateSizeAndOffsetFromAspectRatio(
 
     val value = aspectRatio.value
 
-    val newSize = if (aspectRatio == AspectRatio.Unspecified) {
+    val newSize = if (aspectRatio == AspectRatio.Original) {
         Size(width * coefficient, height * coefficient)
     } else if (value > 1) {
         Size(


### PR DESCRIPTION
This PR addresses #17 
Added an option to enable fixed aspect ratio in dynamic cropping. Also:
* Renamed `AspectRatio.Unspecified` to `AspectRatio.Original` to better match with its description
* Fixed initial overlay rectangle dimensions to conform to the source image aspect ratio

https://user-images.githubusercontent.com/149684/230773467-93ae111e-6c5f-41cf-9a91-3a00e2df1d15.mp4

