### PR TITLE
Fix drawAreaRect not updated on first initialization

### DIFF
--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
@@ -314,9 +314,6 @@ abstract class CropState internal constructor(
         val newPanX = pan.x + panXChange
         val newPanY = pan.y + panYChange
 
-        // Update draw area based on new pan and zoom values
-        drawAreaRect = newDrawAreaRect
-
         if (animate) {
             resetWithAnimation(
                 pan = Offset(newPanX, newPanY),
@@ -330,6 +327,8 @@ abstract class CropState internal constructor(
         }
 
         resetTracking()
+
+        drawAreaRect = updateImageDrawRectFromTransformation()
     }
 
     /**


### PR DESCRIPTION
This PR fixed the issue: When we first loaded the image, the "drawAreaRect" was not updated correctly, so the crop area was incorrect.