### PR TITLE
fix: preserve image rotation after gestures and apply to output

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,9 @@ dependencies {
     // Colorful Customizable Sliders
     implementation 'com.github.SmartToolFactory:Compose-Colorful-Sliders:1.2.0'
     // Color picker
-    implementation 'com.github.SmartToolFactory:Compose-Color-Picker-Bundle:1.0.1'
+    implementation("com.github.SmartToolFactory:Compose-Color-Picker-Bundle:1.0.1") {
+        exclude group: "com.github.SmartToolFactory", module: "Compose-Image-Cropper"
+    }
     // Gestures
     implementation 'com.github.SmartToolFactory:Compose-Extended-Gestures:3.0.0'
     // Animated List

--- a/app/src/main/java/com/smarttoolfactory/composecropper/demo/ImageCropDemo.kt
+++ b/app/src/main/java/com/smarttoolfactory/composecropper/demo/ImageCropDemo.kt
@@ -74,7 +74,8 @@ fun ImageCropDemo() {
                     OutlineType.Rect,
                     RectCropShape(0, "Rect")
                 ),
-                handleSize = handleSize
+                handleSize = handleSize,
+                rotatable = true
             )
         )
     }

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/ImageCropper.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/ImageCropper.kt
@@ -145,7 +145,8 @@ fun ImageCropper(
             cropOutline,
             onCropStart,
             onCropSuccess,
-            cropProperties.requiredSize
+            cropProperties.requiredSize,
+            cropState.rotation
         )
 
         val imageModifier = Modifier
@@ -315,6 +316,7 @@ private fun Crop(
     onCropStart: () -> Unit,
     onCropSuccess: (ImageBitmap) -> Unit,
     requiredSize: IntSize?,
+    rotation: Float
 ) {
 
     val density = LocalDensity.current
@@ -331,7 +333,8 @@ private fun Crop(
                     cropRect,
                     cropOutline,
                     layoutDirection,
-                    density
+                    density,
+                    rotation
                 )
                 if (requiredSize != null) {
                     emit(

--- a/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
+++ b/cropper/src/main/java/com/smarttoolfactory/cropper/state/CropStateImpl.kt
@@ -319,12 +319,14 @@ abstract class CropState internal constructor(
             resetWithAnimation(
                 pan = Offset(newPanX, newPanY),
                 zoom = newZoom,
+                rotation = this.rotation,
                 animationSpec = animationSpec
             )
         } else {
             snapPanXto(newPanX)
             snapPanYto(newPanY)
             snapZoomTo(newZoom)
+            snapRotationTo(this.rotation)
         }
 
         resetTracking()


### PR DESCRIPTION
This PR fixes two related issues with image rotation during cropping:

- When using gestures to rotate the image, the rotation is now preserved after lifting fingers. Previously, it would snap back to 0°.
- The output image now correctly reflects the applied rotation, ensuring the cropped result matches the on-screen preview.

This improves the overall user experience when rotating and cropping images using touch gestures.